### PR TITLE
feat: Add persistent High Score functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A classic Whack-a-Mole game built with HTML, CSS, and JavaScript. Test your refl
 - Start, pause, and restart game functionality
 - Dynamic scoring system
 - Increasing difficulty as time progresses
+- Persistent high score tracking
 - Responsive design for all devices
 - Clean and modern UI
 

--- a/app.js
+++ b/app.js
@@ -2,10 +2,13 @@ const squares = document.querySelectorAll('.square')
 const mole = document.querySelector('.mole')
 const timeLeft = document.querySelector('#time-left')
 const score = document.querySelector('#score')
+const highScore = document.querySelector('#high-score')
 const final = document.querySelector('#final-score')
 const startButton = document.querySelector('#start-button')
 const pauseButton = document.querySelector('#pause-button')
 const restartButton = document.querySelector('#restart-button')
+const resetHighScoreButton = document.querySelector('#reset-highscore-button')
+const highScoreMessage = document.querySelector('#high-score-message')
 
 let result = 0
 let hit = 0
@@ -15,17 +18,55 @@ let countDownTimer = null
 let isGamePaused = false
 let isGameRunning = false
 
+// HIGH SCORE- from local storage 
+function getHighScore() {
+    return parseInt(localStorage.getItem('whackAMoleHighScore')) || 0
+}
+
+function setHighScore(score) {
+    localStorage.setItem('whackAMoleHighScore', score)
+    highScore.textContent = score
+}
+
+function updateHighScoreDisplay() {
+    highScore.textContent = getHighScore()
+}
+
+// compare current score with high score 
+function checkHighScore() {
+    const currentHigh = getHighScore()
+    if (result > currentHigh) {
+        setHighScore(result)
+        highScoreMessage.textContent = '🎉 New High Score! 🎉'
+        highScoreMessage.style.display = 'block'
+        setTimeout(() => {
+            highScoreMessage.style.display = 'none'
+        }, 3000)
+    }
+}
+
+// reset to 0 on clicking reset high score button 
+function resetHighScore() {
+    if (confirm('Are you sure you want to reset the high score?')) {
+        setHighScore(0)
+        highScoreMessage.textContent = 'High Score Reset!'
+        highScoreMessage.style.display = 'block'
+        setTimeout(() => {
+            highScoreMessage.style.display = 'none'
+        }, 2000)
+    }
+}
+
 function resetGame() {
-    // Clear all running timers
     clearInterval(timer)
     clearInterval(countDownTimer)
     
-    // Reset all game variables
     result = 0
     currentTime = 30
     score.textContent = result
     timeLeft.textContent = currentTime
     final.innerHTML = ''
+    highScoreMessage.style.display = 'none'
     document.querySelector('.stats').style.display = 'block'
     squares.forEach(square => square.classList.remove('mole'))
     isGamePaused = false
@@ -51,13 +92,11 @@ function startGame() {
 function pauseGame() {
     if (isGameRunning) {
         if (!isGamePaused) {
-            // Pause
             clearInterval(timer)
             clearInterval(countDownTimer)
             pauseButton.textContent = 'Resume'
             isGamePaused = true
         } else {
-            // Resume
             moveMole()
             countDownTimer = setInterval(countDown, 1000)
             pauseButton.textContent = 'Pause'
@@ -100,6 +139,8 @@ function countDown() {
         clearInterval(countDownTimer)
         clearInterval(timer)
         final.innerHTML = `Your final score is : ${score.textContent}`
+        checkHighScore()
+        
         document.querySelector('.stats').style.display = 'none'
         isGameRunning = false
         startButton.disabled = true
@@ -108,10 +149,12 @@ function countDown() {
     }
 }
 
-// Event listeners for buttons
+// Event listeners
 startButton.addEventListener('click', startGame)
 pauseButton.addEventListener('click', pauseGame)
 restartButton.addEventListener('click', resetGame)
+resetHighScoreButton.addEventListener('click', resetHighScore)
 
-// Initialize game state
+// Initialize
 resetGame()
+updateHighScoreDisplay() 

--- a/app.test.js
+++ b/app.test.js
@@ -9,13 +9,16 @@ describe('Whack-a-Mole Game', () => {
             <div class="stats">
                 <span id="score">0</span>
                 <span id="time-left">30</span>
+                <span id="high-score">0</span>
             </div>
             <div class="controls">
                 <button id="start-button">Start Game</button>
                 <button id="pause-button" disabled>Pause</button>
                 <button id="restart-button" disabled>Restart</button>
+                <button id="reset-highscore-button">Reset High Score</button>
             </div>
             <h2 id="final-score"></h2>
+            <div id="high-score-message"></div>
             <div class="grid">
                 ${Array(9).fill().map((_, i) => `<div class="square" id="${i + 1}"></div>`).join('')}
             </div>
@@ -35,11 +38,13 @@ describe('Whack-a-Mole Game', () => {
         // Clean up timers
         jest.clearAllTimers();
         jest.useRealTimers();
+        localStorage.clear();
     });
     
     test('initial game state', () => {
         expect(document.querySelector('#score').textContent).toBe('0');
         expect(document.querySelector('#time-left').textContent).toBe('30');
+         expect(document.querySelector('#high-score').textContent).toBe('0');
         expect(document.querySelector('#start-button').disabled).toBeFalsy();
         expect(document.querySelector('#pause-button').disabled).toBeTruthy();
         expect(document.querySelector('#restart-button').disabled).toBeTruthy();
@@ -103,4 +108,5 @@ describe('Whack-a-Mole Game', () => {
         expect(document.querySelector('#pause-button').disabled).toBeTruthy();
         expect(document.querySelector('#restart-button').disabled).toBeFalsy();
     });
+
 });

--- a/index.html
+++ b/index.html
@@ -17,13 +17,17 @@
         <span id="score">0</span>
         <b>Time Left:</b>
         <span id="time-left">30</span>
+        <b>High Score:</b>        
+        <span id="high-score">0</span>
    </div>
     <div class="controls">
         <button id="start-button">Start Game</button>
         <button id="pause-button" disabled>Pause</button>
         <button id="restart-button" disabled>Restart</button>
+        <button id="reset-highscore-button">Reset High Score</button>
     </div>
    <h2 id="final-score"></h2>
+   <div id="high-score-message" class="high-score-message"></div>
     <div class="grid">
         <div class="square" id="1"></div>
         <div class="square" id="2"></div>

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,46 @@ button:disabled {
     background-color: #0b7dda;
 }
 
+#reset-highscore-button {
+    background-color: #ff9800;
+}
+
+#reset-highscore-button:hover:not(:disabled) {
+    background-color: #e68900;
+}
+
+.high-score-message {
+    display: none;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #ff6b00;
+    text-align: center;
+    margin: 10px 0;
+    padding: 10px;
+    background-color: #fff3cd;
+    border: 2px solid #ff6b00;
+    border-radius: 5px;
+    animation: bounce 0.5s;
+}
+
+@keyframes bounce {
+    0%, 20%, 60%, 100% {
+        transform: translateY(0);
+    }
+    40% {
+        transform: translateY(-10px);
+    }
+    80% {
+        transform: translateY(-5px);
+    }
+}
+
+#high-score {
+    color: #ff6b00;
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
 @media (max-width: 30.313rem) {
     body {
         height: auto;


### PR DESCRIPTION
## Add High Score Functionality

### Description 
Implemented a persistent highest score tracking for the whack-a-mole game using localStorage. Players can now track their best scores across sessions. 

### Changes
- Added high score display in game stats
- Saved scores persist between browser sessions
- Added a "Reset High Score" button with confirmation 
- New high score celebration message 
- Maintained existing game functionality

### Testing 
- Verified high scores are saved correctly after each game 
- Tested persistence after browser restart 
- Confirmed reset functionality works properly 
- All existing tests passed 

### Notes
High score is visually distinct (orange color) to differentiate from the current score. 

Fixes #4 

