### PR TITLE
Auto label

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,4 +1,4 @@
-name: "Auto Create & Assign Labels"
+name: "Auto Assign Hacktoberfest Label"
 
 on:
   issues:
@@ -13,58 +13,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up labels
-        uses: octokit/request-action@v2
-        id: create-labels
-        with:
-          route: POST /repos/${{ github.repository }}/labels
-          mediaType: '{"previews":["symmetra"]}'
-
-      - name: Create labels if missing and assign
+      - name: Create Hacktoberfest label if missing and assign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Define labels and colors
-          declare -A labels
-          labels["Level 1 / Beginner"]="#7AE7FF"
-          labels["Level 2 / Intermediate"]="#FFAB70"
-          labels["Level 3 / Advanced"]="#FF7F7F"
-          labels["Hacktoberfest"]="#0DAB76"
+          LABEL_NAME="Hacktoberfest"
+          LABEL_COLOR="#0DAB76"  # Green
 
-          # Create labels if they don't exist
-          for label in "${!labels[@]}"; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" \
-              -X POST \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
-              -d "{\"name\":\"$label\",\"color\":\"${labels[$label]}\"}")
-            if [[ "$response" == "422" ]]; then
-              echo "Label '$label' already exists, skipping."
-            else
-              echo "Label '$label' created."
-            fi
-          done
+          # Create label if it doesn't exist
+          response=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
+            -d "{\"name\":\"$LABEL_NAME\",\"color\":\"$LABEL_COLOR\"}")
 
-          # Determine complexity based on title/body
-          TITLE="${{ github.event.issue.title || github.event.pull_request.title }}"
-          BODY="${{ github.event.issue.body || github.event.pull_request.body }}"
-
-          LEVEL_LABEL=""
-          if echo "$TITLE$BODY" | grep -iqE "typo|doc|readme|ui"; then
-            LEVEL_LABEL="Level 1 / Beginner"
-          elif echo "$TITLE$BODY" | grep -iqE "feature|bug|small"; then
-            LEVEL_LABEL="Level 2 / Intermediate"
+          if [[ "$response" == "422" ]]; then
+            echo "Label '$LABEL_NAME' already exists, skipping."
           else
-            LEVEL_LABEL="Level 3 / Advanced"
+            echo "Label '$LABEL_NAME' created."
           fi
 
-          # Assign labels to issue or PR
+          # Assign Hacktoberfest label to issue or PR
           ISSUE_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
           curl -s -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/labels \
-            -d "{\"labels\":[\"Hacktoberfest\",\"$LEVEL_LABEL\"]}"
-          
-          echo "Labels assigned: Hacktoberfest, $LEVEL_LABEL"
+            -d "{\"labels\":[\"$LABEL_NAME\"]}"
+
+          echo "Label assigned: $LABEL_NAME"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,70 @@
+name: "Auto Create & Assign Labels"
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up labels
+        uses: octokit/request-action@v2
+        id: create-labels
+        with:
+          route: POST /repos/${{ github.repository }}/labels
+          mediaType: '{"previews":["symmetra"]}'
+
+      - name: Create labels if missing and assign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Define labels and colors
+          declare -A labels
+          labels["Level 1 / Beginner"]="#7AE7FF"
+          labels["Level 2 / Intermediate"]="#FFAB70"
+          labels["Level 3 / Advanced"]="#FF7F7F"
+          labels["Hacktoberfest"]="#0DAB76"
+
+          # Create labels if they don't exist
+          for label in "${!labels[@]}"; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" \
+              -X POST \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${GITHUB_REPOSITORY}/labels \
+              -d "{\"name\":\"$label\",\"color\":\"${labels[$label]}\"}")
+            if [[ "$response" == "422" ]]; then
+              echo "Label '$label' already exists, skipping."
+            else
+              echo "Label '$label' created."
+            fi
+          done
+
+          # Determine complexity based on title/body
+          TITLE="${{ github.event.issue.title || github.event.pull_request.title }}"
+          BODY="${{ github.event.issue.body || github.event.pull_request.body }}"
+
+          LEVEL_LABEL=""
+          if echo "$TITLE$BODY" | grep -iqE "typo|doc|readme|ui"; then
+            LEVEL_LABEL="Level 1 / Beginner"
+          elif echo "$TITLE$BODY" | grep -iqE "feature|bug|small"; then
+            LEVEL_LABEL="Level 2 / Intermediate"
+          else
+            LEVEL_LABEL="Level 3 / Advanced"
+          fi
+
+          # Assign labels to issue or PR
+          ISSUE_NUMBER="${{ github.event.issue.number || github.event.pull_request.number }}"
+          curl -s -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/$ISSUE_NUMBER/labels \
+            -d "{\"labels\":[\"Hacktoberfest\",\"$LEVEL_LABEL\"]}"
+          
+          echo "Labels assigned: Hacktoberfest, $LEVEL_LABEL"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #47 

## Rationale for this change

This PR adds an **automatic label assignment workflow** for all newly created issues and pull requests.  
It ensures:

- The `Hacktoberfest` label is automatically created (if not already present) with proper color.  
- Labels are assigned automatically to all new issues and PRs.  
- Works for both **issues and PRs**, simplifying contribution management.

This improves consistency and saves manual labeling effort for contributors.

## What changes are included in this PR?

- Added a new GitHub Actions workflow file:  
  `.github/workflows/auto-label.yml`  
- Logic to:
  - Create the `Hacktoberfest` label if missing
  - Assign the `Hacktoberfest` label automatically to new issues and PRs

## Are these changes tested?

- Workflow tested by creating **dummy issues and PRs** in a separate branch to ensure the label is automatically applied.  
- Verified that existing labels are not duplicated and the color matches the defined scheme.

## Are there any user-facing changes?

- No direct user-facing changes.  
- Contributors will see the `Hacktoberfest` label applied automatically when they open an issue or PR.
